### PR TITLE
Fix header parsing bug

### DIFF
--- a/data/Sample.py
+++ b/data/Sample.py
@@ -258,8 +258,8 @@ class TumorSample:
         file_in = open(filen) if type(filen) == str else filen
 
         header = file_in.readline()
-        while header[0] == "#" or not header.strip():
-            header = header.readline()
+        while header.startswith("#") or not header.strip():
+            header = file_in.readline()
         header = header.strip().split("\t")
         h = collections.OrderedDict([[x[1], x[0]] for x in enumerate(header)])
 


### PR DESCRIPTION
## Summary
- fix `_read_ccf_from_txt` to correctly skip comment lines when reading header

## Testing
- `python -m py_compile data/Sample.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684039bcbce4832095a2c3c740745d27